### PR TITLE
Use skipinitialspace option in read_csv

### DIFF
--- a/datapump.py
+++ b/datapump.py
@@ -14,7 +14,7 @@ import shutil
 import dateparser
 from jsonschema import validate
 
-version = '1.1'
+version = '1.2'
 formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 
 jobschema = {
@@ -180,7 +180,8 @@ def datapump(inputdir, processeddir, problemsdir, datecolumn, dateformats,
                 x, date_formats=dateformats_list)
 
             df = pd.read_csv(inputfile, parse_dates=[
-                             datecolumn], date_parser=custom_date_parser)
+                             datecolumn], date_parser=custom_date_parser,
+                             skipinitialspace=True)
 
             if job['Dedupe']:
                 pkey_list = list(job['PrimaryKey'].split(','))


### PR DESCRIPTION
So it will be more tolerant of less well-formed CSV files that don't use quoted column names. This also handles leading spaces in the CSV body as well.